### PR TITLE
Clear Product model to remove invalid data

### DIFF
--- a/app/code/community/Ometria/Api/Model/Api.php
+++ b/app/code/community/Ometria/Api/Model/Api.php
@@ -246,7 +246,8 @@ class Ometria_Api_Model_Api extends Mage_Api_Model_Resource_Abstract {
                 $listings = isset($product_per_store_attributes[$id]) ? $product_per_store_attributes[$id] : array();
                 $listings = $this->_resolveStoreListings($listings, $store_ids, $productMediaConfig);
                 $info['store_listings'] = $listings;
-
+                
+                $product->clearInstance();
             } catch(Exception $e){
                 $info = false;
             }


### PR DESCRIPTION
When calling ometria_api.get_products with multiple product IDs, it's possible for product data to persist as the model is not cleaned before it is loaded.